### PR TITLE
Preserve current window when exiting with <Esc>

### DIFF
--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -45,6 +45,7 @@ function! s:PickerTermopen(list_command, vim_command) abort
       catch /E684/
       endtry
       call delete(self.filename)
+      unlet g:picker_previous_winid
     endif
   endfunction
 
@@ -52,6 +53,7 @@ function! s:PickerTermopen(list_command, vim_command) abort
   let l:term_command = a:list_command . '|' . g:picker_selector . '>' .
         \ l:callback.filename
   call termopen(l:term_command, l:callback)
+  let g:picker_previous_winid = l:callback.window_id
   setfiletype picker
   startinsert
 endfunction
@@ -110,4 +112,10 @@ endfunction
 
 function! picker#Help() abort
   call s:Picker(s:ListHelpTagsCommand(), 'help')
+endfunction
+
+function! picker#Close() abort
+  quit
+  call win_gotoid(g:picker_previous_winid)
+  unlet g:picker_previous_winid
 endfunction

--- a/ftplugin/picker.vim
+++ b/ftplugin/picker.vim
@@ -3,5 +3,5 @@
 " Source:     https://github.com/srstevenson/vim-picker
 
 if exists(':tnoremap') == 2
-  tnoremap <buffer> <silent> <Esc> <C-\><C-n>:quit<CR>
+  tnoremap <buffer> <silent> <Esc> <C-\><C-n>:call picker#Close()<CR>
 endif


### PR DESCRIPTION
When <kbd>Esc</kbd> is used to exit the vim-picker window in Neovim, the callback which restores focus to the original window isn't triggered. We now explicitly move back to the original window in a new function, `picker#Close()`, called from the <kbd>Esc</kbd> mapping.