### PR TITLE
Fix newlines in PickerBuffer command

### DIFF
--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -21,7 +21,7 @@ function! s:ListBuffersCommand() abort
   let l:buffers = range(1, bufnr('$'))
   let l:listed = filter(l:buffers, 'buflisted(v:val)')
   let l:names = map(l:listed, 'bufname(v:val)')
-  return 'echo ' . join(l:names, '\n')
+  return 'echo ' . join(l:names, '\\n')
 endfunction
 
 function! s:ListTagsCommand() abort


### PR DESCRIPTION
Newline expression requires escaped backslash, lest the backslash is
consumed and fzy's stdin receives one line of many filenames separated
by the letter n.

Not sure why this is, but it works.  Tested on neovim 0.1.6 and vim 8.0.0170.

#### Test procedure:

1.  cd /tmp
2.  touch a.txt b.txt
3.  nvim a.txt b.txt  # or vim
4.  :PickerBuffer<CR>

#### Current Behavior

![image](https://cloud.githubusercontent.com/assets/636691/23097820/e291b216-f60c-11e6-81e2-bb62a7bddd96.png)

#### Expected Behavior (and provided by patch)

![image](https://cloud.githubusercontent.com/assets/636691/23097824/ffa3a242-f60c-11e6-93ee-313bbc99e0fd.png)
