### PR TITLE
Quote argument to echo

### DIFF
--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -21,7 +21,7 @@ function! s:ListBuffersCommand() abort
   let l:buffers = range(1, bufnr('$'))
   let l:listed = filter(l:buffers, 'buflisted(v:val)')
   let l:names = map(l:listed, 'bufname(v:val)')
-  return 'echo ' . join(l:names, '\n')
+  return 'echo "' . join(l:names, "\n"). '"'
 endfunction
 
 function! s:ListTagsCommand() abort


### PR DESCRIPTION
The argument to echo contains newline characters, and so must be quoted to ensure the newlines are printed correctly when Vim is configured to use bash, fish, or zsh to run shell commands.

Thanks to @boxofrox for reporting this.