### PR TITLE
Add PickerBufferTag

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ vim-picker provides the following commands:
 * `:PickerTabedit`: Pick a file to edit in a new tab.
 * `:PickerVsplit`: Pick a file to edit in a new vertical split.
 * `:PickerBuffer`: Pick a buffer to edit in the current window.
+* `:PickerBufferTag`: Pick a tag to jump to in the current buffer.
 * `:PickerTag`: Pick a tag to jump to in the current window.
 * `:PickerHelp`: Pick a help tag to jump to in the current window.
 
@@ -90,6 +91,7 @@ vim-picker defines the following [`<Plug>`][plug-mappings] mappings:
 * `<Plug>PickerTabedit`: Execute `:PickerTabedit`.
 * `<Plug>PickerVsplit`: Execute `:PickerVsplit`.
 * `<Plug>PickerBuffer`: Execute `:PickerBuffer`.
+* `<Plug>PickerBufferTag`: Execute `:PickerBufferTag`.
 * `<Plug>PickerTag`: Execute `:PickerTag`.
 * `<Plug>PickerHelp`: Execute `:PickerHelp`.
 
@@ -105,6 +107,7 @@ nmap <unique> <leader>pt <Plug>PickerTabedit
 nmap <unique> <leader>pv <Plug>PickerVsplit
 nmap <unique> <leader>pb <Plug>PickerBuffer
 nmap <unique> <leader>p] <Plug>PickerTag
+nmap <unique> <leader>pb] <Plug>PickerBufferTag
 nmap <unique> <leader>ph <Plug>PickerHelp
 ```
 

--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -28,6 +28,10 @@ function! s:ListTagsCommand() abort
   return 'grep -v "^!_TAG_" ' . join(tagfiles()) . ' | cut -f 1 | sort -u'
 endfunction
 
+function! s:ListBufferTagsCommand(filename) abort
+  return 'ctags -f - ' . a:filename . ' | grep -v "^!_TAG_" | cut -f 1 | sort -u'
+endfunction
+
 function! s:ListHelpTagsCommand() abort
   return 'cut -f 1 ' . join(findfile('doc/tags', &runtimepath, -1))
 endfunction
@@ -171,6 +175,10 @@ endfunction
 
 function! picker#Tag() abort
   call s:PickString(s:ListTagsCommand(), 'tag')
+endfunction
+
+function! picker#BufferTag() abort
+  call s:PickString(s:ListBufferTagsCommand(expand('%:p')), 'tag')
 endfunction
 
 function! picker#Help() abort

--- a/plugin/picker.vim
+++ b/plugin/picker.vim
@@ -26,6 +26,7 @@ command -bar PickerTabedit call picker#Tabedit()
 command -bar PickerVsplit call picker#Vsplit()
 command -bar PickerBuffer call picker#Buffer()
 command -bar PickerTag call picker#Tag()
+command -bar PickerBufferTag call picker#BufferTag()
 command -bar PickerHelp call picker#Help()
 
 nnoremap <silent> <Plug>PickerEdit :PickerEdit<CR>
@@ -34,4 +35,5 @@ nnoremap <silent> <Plug>PickerTabedit :PickerTabedit<CR>
 nnoremap <silent> <Plug>PickerVsplit :PickerVsplit<CR>
 nnoremap <silent> <Plug>PickerBuffer :PickerBuffer<CR>
 nnoremap <silent> <Plug>PickerTag :PickerTag<CR>
+nnoremap <silent> <Plug>PickerBufferTag :PickerBufferTag<CR>
 nnoremap <silent> <Plug>PickerHelp :PickerHelp<CR>


### PR DESCRIPTION
`:PickerTag` is a little slow against large tag files. `:PickerBufferTag` will run `ctags` against the current buffer then passes it along.

My vimscript is far from good, so let me know if I have made any dumb mistakes!