### PR TITLE
Expand docstrings

### DIFF
--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -3,11 +3,15 @@
 " Source:     https://github.com/srstevenson/vim-picker
 
 function! s:InGitRepository() abort
+    " Determine if the current directory is a Git repository.
     let l:_ = system('git rev-parse --is-inside-work-tree')
     return v:shell_error == 0
 endfunction
 
 function! s:ListFilesCommand() abort
+    " Return a shell command suitable for listing the files in the
+    " current directory, based on whether the current directory is a Git
+    " repository and if ripgrep is installed.
     if s:InGitRepository()
         return 'git ls-files --cached --exclude-standard --others'
     elseif executable('rg')
@@ -18,6 +22,7 @@ function! s:ListFilesCommand() abort
 endfunction
 
 function! s:ListBuffersCommand() abort
+    " Return a shell command which will list current listed buffers.
     let l:buffers = range(1, bufnr('$'))
     let l:listed = filter(l:buffers, 'buflisted(v:val)')
     let l:names = map(l:listed, 'bufname(v:val)')
@@ -25,14 +30,18 @@ function! s:ListBuffersCommand() abort
 endfunction
 
 function! s:ListTagsCommand() abort
+    " Return a shell command which will list known tags.
     return 'grep -v "^!_TAG_" ' . join(tagfiles()) . ' | cut -f 1 | sort -u'
 endfunction
 
 function! s:ListBufferTagsCommand(filename) abort
+    " Return a shell command which will list known tags in the current
+    " file.
     return 'ctags -f - ' . a:filename . ' | cut -f 1 | sort -u'
 endfunction
 
 function! s:ListHelpTagsCommand() abort
+    " Return a shell command which will list known Vim help topics.
     return 'cut -f 1 ' . join(findfile('doc/tags', &runtimepath, -1))
 endfunction
 
@@ -173,49 +182,75 @@ function! s:PickFile(list_command, vim_command) abort
 endfunction
 
 function! picker#CheckIsNumber(variable, name) abort
+    " Print an error message if variable is not of type Number.
+    "
+    " Parameters
+    " ----------
+    " variable : Any
+    "     Value of the variable.
+    " name : String
+    "     Name of the variable.
     if type(a:variable) != type(0)
         echomsg 'Error:' a:name 'must be a number'
     endif
 endfunction
 
 function! picker#CheckIsString(variable, name) abort
+    " Print an error message if variable is not of type String.
+    "
+    " Parameters
+    " ----------
+    " variable : Any
+    "     Value of the variable.
+    " name : String
+    "     Name of the variable.
     if type(a:variable) != type('')
         echomsg 'Error:' a:name 'must be a string'
     endif
 endfunction
 
 function! picker#Edit() abort
+    " Run fuzzy selector to choose a file and call edit on it.
     call s:PickFile(s:ListFilesCommand(), 'edit')
 endfunction
 
 function! picker#Split() abort
+    " Run fuzzy selector to choose a file and call split on it.
     call s:PickFile(s:ListFilesCommand(), 'split')
 endfunction
 
 function! picker#Tabedit() abort
+    " Run fuzzy selector to choose a file and call tabedit on it.
     call s:PickFile(s:ListFilesCommand(), 'tabedit')
 endfunction
 
 function! picker#Vsplit() abort
+    " Run fuzzy selector to choose a file and call vsplit on it.
     call s:PickFile(s:ListFilesCommand(), 'vsplit')
 endfunction
 
 function! picker#Buffer() abort
+    " Run fuzzy selector to choose a buffer and call buffer on it.
     call s:PickFile(s:ListBuffersCommand(), 'buffer')
 endfunction
 
 function! picker#Tag() abort
+    " Run fuzzy selector to choose a tag and call tag on it.
     call s:PickString(s:ListTagsCommand(), 'tag')
 endfunction
 
 function! picker#BufferTag() abort
+    " Run fuzzy selector to choose a tag from the current file and call
+    " tag on it.
     call s:PickString(s:ListBufferTagsCommand(expand('%:p')), 'tag')
 endfunction
 
 function! picker#Help() abort
+    " Run fuzzy selector to choose a help topic and call help on it.
     call s:PickString(s:ListHelpTagsCommand(), 'help')
 endfunction
 
 function! picker#Close() abort
+    " Send SIGTERM to the currently running fuzzy selector process.
     call jobstop(s:picker_job_id)
 endfunction

--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -3,37 +3,37 @@
 " Source:     https://github.com/srstevenson/vim-picker
 
 function! s:InGitRepository() abort
-  let l:_ = system('git rev-parse --is-inside-work-tree')
-  return v:shell_error == 0
+    let l:_ = system('git rev-parse --is-inside-work-tree')
+    return v:shell_error == 0
 endfunction
 
 function! s:ListFilesCommand() abort
-  if s:InGitRepository()
-    return 'git ls-files --cached --exclude-standard --others'
-  elseif executable('rg')
-    return 'rg --files'
-  else
-    return 'find . -type f'
-  endif
+    if s:InGitRepository()
+        return 'git ls-files --cached --exclude-standard --others'
+    elseif executable('rg')
+        return 'rg --files'
+    else
+        return 'find . -type f'
+    endif
 endfunction
 
 function! s:ListBuffersCommand() abort
-  let l:buffers = range(1, bufnr('$'))
-  let l:listed = filter(l:buffers, 'buflisted(v:val)')
-  let l:names = map(l:listed, 'bufname(v:val)')
-  return 'echo "' . join(l:names, "\n"). '"'
+    let l:buffers = range(1, bufnr('$'))
+    let l:listed = filter(l:buffers, 'buflisted(v:val)')
+    let l:names = map(l:listed, 'bufname(v:val)')
+    return 'echo "' . join(l:names, "\n"). '"'
 endfunction
 
 function! s:ListTagsCommand() abort
-  return 'grep -v "^!_TAG_" ' . join(tagfiles()) . ' | cut -f 1 | sort -u'
+    return 'grep -v "^!_TAG_" ' . join(tagfiles()) . ' | cut -f 1 | sort -u'
 endfunction
 
 function! s:ListBufferTagsCommand(filename) abort
-  return 'ctags -f - ' . a:filename . ' | cut -f 1 | sort -u'
+    return 'ctags -f - ' . a:filename . ' | cut -f 1 | sort -u'
 endfunction
 
 function! s:ListHelpTagsCommand() abort
-  return 'cut -f 1 ' . join(findfile('doc/tags', &runtimepath, -1))
+    return 'cut -f 1 ' . join(findfile('doc/tags', &runtimepath, -1))
 endfunction
 
 " PickerTermopen
@@ -48,32 +48,33 @@ endfunction
 "   - callback function that provides the string selected by the user to the
 "     caller.
 function! s:PickerTermopen(list_command, vim_command, callback) abort
-  let l:callback = {
-        \ 'window_id': win_getid(),
-        \ 'filename': tempname(),
-        \ 'callback': a:callback}
+    let l:callback = {
+                \ 'window_id': win_getid(),
+                \ 'filename': tempname(),
+                \ 'callback': a:callback
+                \ }
 
-  function! l:callback.on_exit(job_id, data, event) abort
-    bdelete!
-    call win_gotoid(self.window_id)
-    if filereadable(self.filename)
-      try
-        call self.callback.on_select(readfile(self.filename)[0])
-      catch /E684/
-      endtry
-      call delete(self.filename)
-    endif
-  endfunction
+    function! l:callback.on_exit(job_id, data, event) abort
+        bdelete!
+        call win_gotoid(self.window_id)
+        if filereadable(self.filename)
+            try
+                call self.callback.on_select(readfile(self.filename)[0])
+            catch /E684/
+            endtry
+            call delete(self.filename)
+        endif
+    endfunction
 
-  execute 'botright' g:picker_height . 'new'
-  let l:term_command = a:list_command . '|' . g:picker_selector . '>' .
-        \ l:callback.filename
-  let s:picker_job_id = termopen(l:term_command, l:callback)
-  setfiletype picker
-  let b:picker_statusline = 'Picker [command: ' . a:vim_command .
-              \ ', directory: ' . getcwd() . ']'
-  setlocal statusline=%{b:picker_statusline}
-  startinsert
+    execute 'botright' g:picker_height . 'new'
+    let l:term_command = a:list_command . '|' . g:picker_selector . '>' .
+                \ l:callback.filename
+    let s:picker_job_id = termopen(l:term_command, l:callback)
+    setfiletype picker
+    let b:picker_statusline = 'Picker [command: ' . a:vim_command .
+                \ ', directory: ' . getcwd() . ']'
+    setlocal statusline=%{b:picker_statusline}
+    startinsert
 endfunction
 
 " PickerSystemlist
@@ -84,11 +85,11 @@ endfunction
 "   - callback function that provides the string selected by the user to the
 "     caller.
 function! s:PickerSystemlist(list_command, callback) abort
-  try
-    call a:callback.on_select(systemlist(a:list_command . '|' . g:picker_selector)[0])
-  catch /E684/
-  endtry
-  redraw!
+    try
+        call a:callback.on_select(systemlist(a:list_command . '|' . g:picker_selector)[0])
+    catch /E684/
+    endtry
+    redraw!
 endfunction
 
 " Picker
@@ -101,16 +102,16 @@ endfunction
 "   - callback function that provides the string selected by the user to the
 "     caller.
 function! s:Picker(list_command, vim_command, callback) abort
-  if !executable(split(g:picker_selector)[0])
-    echomsg 'Error:' split(g:picker_selector)[0] 'executable not found'
-    return
-  endif
+    if !executable(split(g:picker_selector)[0])
+        echomsg 'Error:' split(g:picker_selector)[0] 'executable not found'
+        return
+    endif
 
-  if exists('*termopen')
-    call s:PickerTermopen(a:list_command, a:vim_command, a:callback)
-  else
-    call s:PickerSystemlist(a:list_command, a:callback)
-  endif
+    if exists('*termopen')
+        call s:PickerTermopen(a:list_command, a:vim_command, a:callback)
+    else
+        call s:PickerSystemlist(a:list_command, a:callback)
+    endif
 endfunction
 
 " PickString
@@ -118,13 +119,13 @@ endfunction
 " create a callback that executes a vim command against the user's
 " unadulterated selection, then display the Picker UI.
 function! s:PickString(list_command, vim_command) abort
-  let l:callback = {'vim_command': a:vim_command}
+    let l:callback = {'vim_command': a:vim_command}
 
-  function! l:callback.on_select(selection) abort
-    exec self.vim_command a:selection
-  endfunction
+    function! l:callback.on_select(selection) abort
+        exec self.vim_command a:selection
+    endfunction
 
-  call s:Picker(a:list_command, a:vim_command, l:callback)
+    call s:Picker(a:list_command, a:vim_command, l:callback)
 endfunction
 
 " PickFile
@@ -132,59 +133,59 @@ endfunction
 " create a callback that executes a vim command against the user's selection
 " escaped for use as a filename, then display the Picker UI.
 function! s:PickFile(list_command, vim_command) abort
-  let l:callback = {'vim_command': a:vim_command}
+    let l:callback = {'vim_command': a:vim_command}
 
-  function! l:callback.on_select(selection) abort
-    exec self.vim_command fnameescape(a:selection)
-  endfunction
+    function! l:callback.on_select(selection) abort
+        exec self.vim_command fnameescape(a:selection)
+    endfunction
 
-  call s:Picker(a:list_command, a:vim_command, l:callback)
+    call s:Picker(a:list_command, a:vim_command, l:callback)
 endfunction
 
 function! picker#CheckIsNumber(variable, name) abort
-  if type(a:variable) != type(0)
-    echomsg 'Error:' a:name 'must be a number'
-  endif
+    if type(a:variable) != type(0)
+        echomsg 'Error:' a:name 'must be a number'
+    endif
 endfunction
 
 function! picker#CheckIsString(variable, name) abort
-  if type(a:variable) != type('')
-    echomsg 'Error:' a:name 'must be a string'
-  endif
+    if type(a:variable) != type('')
+        echomsg 'Error:' a:name 'must be a string'
+    endif
 endfunction
 
 function! picker#Edit() abort
-  call s:PickFile(s:ListFilesCommand(), 'edit')
+    call s:PickFile(s:ListFilesCommand(), 'edit')
 endfunction
 
 function! picker#Split() abort
-  call s:PickFile(s:ListFilesCommand(), 'split')
+    call s:PickFile(s:ListFilesCommand(), 'split')
 endfunction
 
 function! picker#Tabedit() abort
-  call s:PickFile(s:ListFilesCommand(), 'tabedit')
+    call s:PickFile(s:ListFilesCommand(), 'tabedit')
 endfunction
 
 function! picker#Vsplit() abort
-  call s:PickFile(s:ListFilesCommand(), 'vsplit')
+    call s:PickFile(s:ListFilesCommand(), 'vsplit')
 endfunction
 
 function! picker#Buffer() abort
-  call s:PickFile(s:ListBuffersCommand(), 'buffer')
+    call s:PickFile(s:ListBuffersCommand(), 'buffer')
 endfunction
 
 function! picker#Tag() abort
-  call s:PickString(s:ListTagsCommand(), 'tag')
+    call s:PickString(s:ListTagsCommand(), 'tag')
 endfunction
 
 function! picker#BufferTag() abort
-  call s:PickString(s:ListBufferTagsCommand(expand('%:p')), 'tag')
+    call s:PickString(s:ListBufferTagsCommand(expand('%:p')), 'tag')
 endfunction
 
 function! picker#Help() abort
-  call s:PickString(s:ListHelpTagsCommand(), 'help')
+    call s:PickString(s:ListHelpTagsCommand(), 'help')
 endfunction
 
 function! picker#Close() abort
-  call jobstop(s:picker_job_id)
+    call jobstop(s:picker_job_id)
 endfunction

--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -4,6 +4,11 @@
 
 function! s:InGitRepository() abort
     " Determine if the current directory is a Git repository.
+    "
+    " Returns
+    " -------
+    " Number
+    "     1 inside a Git repository, 0 otherwise.
     let l:_ = system('git rev-parse --is-inside-work-tree')
     return v:shell_error == 0
 endfunction
@@ -12,6 +17,11 @@ function! s:ListFilesCommand() abort
     " Return a shell command suitable for listing the files in the
     " current directory, based on whether the current directory is a Git
     " repository and if ripgrep is installed.
+    "
+    " Returns
+    " -------
+    " String
+    "     Shell command to list files in the current directory.
     if s:InGitRepository()
         return 'git ls-files --cached --exclude-standard --others'
     elseif executable('rg')
@@ -23,6 +33,11 @@ endfunction
 
 function! s:ListBuffersCommand() abort
     " Return a shell command which will list current listed buffers.
+    "
+    " Returns
+    " -------
+    " String
+    "     Shell command to list current listed buffers.
     let l:buffers = range(1, bufnr('$'))
     let l:listed = filter(l:buffers, 'buflisted(v:val)')
     let l:names = map(l:listed, 'bufname(v:val)')
@@ -31,17 +46,32 @@ endfunction
 
 function! s:ListTagsCommand() abort
     " Return a shell command which will list known tags.
+    "
+    " Returns
+    " -------
+    " String
+    "     Shell command to list known tags.
     return 'grep -v "^!_TAG_" ' . join(tagfiles()) . ' | cut -f 1 | sort -u'
 endfunction
 
 function! s:ListBufferTagsCommand(filename) abort
     " Return a shell command which will list known tags in the current
     " file.
+    "
+    " Returns
+    " -------
+    " String
+    "     Shell command to list known tags in the current file.
     return 'ctags -f - ' . a:filename . ' | cut -f 1 | sort -u'
 endfunction
 
 function! s:ListHelpTagsCommand() abort
-    " Return a shell command which will list known Vim help topics.
+    " Return a shell command which will list known help topics.
+    "
+    " Returns
+    " -------
+    " String
+    "     Shell command to list known help topics.
     return 'cut -f 1 ' . join(findfile('doc/tags', &runtimepath, -1))
 endfunction
 

--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -36,18 +36,23 @@ function! s:ListHelpTagsCommand() abort
     return 'cut -f 1 ' . join(findfile('doc/tags', &runtimepath, -1))
 endfunction
 
-" PickerTermopen
-"
-" open terminal in new window as UI for user to fuzzy select within.
-"
-" @param list_command - String
-"   - shell command to generate list user will choose from.
-" @param vim_command - String
-"   - vim ex command that will be invoked against the user's selection.
-" @param callback.on_select - (String -> Void)
-"   - callback function that provides the string selected by the user to the
-"     caller.
 function! s:PickerTermopen(list_command, vim_command, callback) abort
+    " Open a terminal emulator buffer in a new window, execute
+    " list_command piping its output to the fuzzy selector, and call
+    " callback.on_select with the item selected by the user as the first
+    " argument.
+    "
+    " Parameters
+    " ----------
+    " list_command : String
+    "     Shell command to generate list user will choose from.
+    " vim_command : String
+    "     Readable representation of the Vim command which will be
+    "     invoked against the user's selection, for display in the
+    "     statusline.
+    " callback.on_select : String -> Void
+    "     Function executed with the item selected by the user as the
+    "     first argument.
     let l:callback = {
                 \ 'window_id': win_getid(),
                 \ 'filename': tempname(),
@@ -77,14 +82,18 @@ function! s:PickerTermopen(list_command, vim_command, callback) abort
     startinsert
 endfunction
 
-" PickerSystemlist
-"
-" @param list_command - String
-"   - shell command to generate list user will choose from.
-" @param callback.on_select - (String -> Void)
-"   - callback function that provides the string selected by the user to the
-"     caller.
 function! s:PickerSystemlist(list_command, callback) abort
+    " Execute list_command in a shell, piping its output to the fuzzy
+    " selector, and call callback.on_select with the line selected by
+    " the user as the first argument.
+    "
+    " Parameters
+    " ----------
+    " list_command : String
+    "     Shell command to generate list user will choose from.
+    " callback.on_select : String -> Void
+    "     Function executed with the item selected by the user as the
+    "     first argument.
     try
         call a:callback.on_select(systemlist(a:list_command . '|' . g:picker_selector)[0])
     catch /E684/
@@ -92,16 +101,22 @@ function! s:PickerSystemlist(list_command, callback) abort
     redraw!
 endfunction
 
-" Picker
-"
-" @param list_command - String
-"   - shell command to generate list user will choose from.
-" @param vim_command - String
-"   - vim ex command that will be invoked against the user's selection.
-" @param callback.on_select - (String -> Void)
-"   - callback function that provides the string selected by the user to the
-"     caller.
 function! s:Picker(list_command, vim_command, callback) abort
+    " Invoke callback.on_select on the line of output of list_command
+    " selected by the user, using PickerTermopen() in Neovim and
+    " PickerSystemlist() otherwise.
+    "
+    " Parameters
+    " ----------
+    " list_command : String
+    "     Shell command to generate list user will choose from.
+    " vim_command : String
+    "     Readable representation of the Vim command which will be
+    "     invoked against the user's selection, for display in the
+    "     statusline.
+    " callback.on_select : String -> Void
+    "     Function executed with the item selected by the user as the
+    "     first argument.
     if !executable(split(g:picker_selector)[0])
         echomsg 'Error:' split(g:picker_selector)[0] 'executable not found'
         return
@@ -114,11 +129,18 @@ function! s:Picker(list_command, vim_command, callback) abort
     endif
 endfunction
 
-" PickString
-"
-" create a callback that executes a vim command against the user's
-" unadulterated selection, then display the Picker UI.
 function! s:PickString(list_command, vim_command) abort
+    " Create a callback that executes a Vim command against the user's
+    " unadulterated selection, and invoke Picker() with that callback.
+    "
+    " Parameters
+    " ----------
+    " list_command : String
+    "     Shell command to generate list user will choose from.
+    " vim_command : String
+    "     Readable representation of the Vim command which will be
+    "     invoked against the user's selection, for display in the
+    "     statusline.
     let l:callback = {'vim_command': a:vim_command}
 
     function! l:callback.on_select(selection) abort
@@ -128,11 +150,19 @@ function! s:PickString(list_command, vim_command) abort
     call s:Picker(a:list_command, a:vim_command, l:callback)
 endfunction
 
-" PickFile
-"
-" create a callback that executes a vim command against the user's selection
-" escaped for use as a filename, then display the Picker UI.
 function! s:PickFile(list_command, vim_command) abort
+    " Create a callback that executes a Vim command against the user's
+    " selection escaped for use as a filename, and invoke Picker() with
+    " that callback.
+    "
+    " Parameters
+    " ----------
+    " list_command : String
+    "     Shell command to generate list user will choose from.
+    " vim_command : String
+    "     Readable representation of the Vim command which will be
+    "     invoked against the user's selection, for display in the
+    "     statusline.
     let l:callback = {'vim_command': a:vim_command}
 
     function! l:callback.on_select(selection) abort

--- a/ftplugin/picker.vim
+++ b/ftplugin/picker.vim
@@ -3,5 +3,5 @@
 " Source:     https://github.com/srstevenson/vim-picker
 
 if exists(':tnoremap') == 2
-  tnoremap <buffer> <silent> <Esc> <C-\><C-n>:call picker#Close()<CR>
+    tnoremap <buffer> <silent> <Esc> <C-\><C-n>:call picker#Close()<CR>
 endif

--- a/plugin/picker.vim
+++ b/plugin/picker.vim
@@ -3,21 +3,21 @@
 " Source:     https://github.com/srstevenson/vim-picker
 
 if exists('g:loaded_picker')
-  finish
+    finish
 endif
 
 let g:loaded_picker = 1
 
 if exists('g:picker_selector')
-  call picker#CheckIsString(g:picker_selector, 'g:picker_selector')
+    call picker#CheckIsString(g:picker_selector, 'g:picker_selector')
 else
-  let g:picker_selector = 'fzy --lines=' . &lines
+    let g:picker_selector = 'fzy --lines=' . &lines
 endif
 
 if exists('g:picker_height')
-  call picker#CheckIsNumber(g:picker_height, 'g:picker_height')
+    call picker#CheckIsNumber(g:picker_height, 'g:picker_height')
 else
-  let g:picker_height = 10
+    let g:picker_height = 10
 endif
 
 command -bar PickerEdit call picker#Edit()


### PR DESCRIPTION
This PR adds docstrings to those functions which didn't previously have one, documenting the type and meaning of function parameters and return values. For lack of a conventional docstring format for Vimscript, one based on [Python conventions](https://www.python.org/dev/peps/pep-0257/) is adopted.