### PR TITLE
Set statusline before setting filetype

### DIFF
--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -114,10 +114,10 @@ function! s:PickerTermopen(list_command, vim_command, callback) abort
     let l:term_command = a:list_command . '|' . g:picker_selector . '>' .
                 \ l:callback.filename
     let s:picker_job_id = termopen(l:term_command, l:callback)
-    setfiletype picker
     let b:picker_statusline = 'Picker [command: ' . a:vim_command .
                 \ ', directory: ' . getcwd() . ']'
     setlocal statusline=%{b:picker_statusline}
+    setfiletype picker
     startinsert
 endfunction
 


### PR DESCRIPTION
This allows the user to override the default statusline in the picker window using an `autocmd` on the `FileType` event for the `picker` filetype. For example:

```vim
augroup picker_statusline
    autocmd!
    autocmd FileType picker setlocal statusline='example'
augroup END
```