### PR TITLE
Allow configuration of how split window is opened

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ but any well behaved command line filter should work. If you run Vim within
 distributed with `fzy` will open the fuzzy selector in a new tmux pane below
 Vim, providing an interface similar to using vim-picker with Neovim.
 
+By default, vim-picker in Neovim will run the fuzzy selector in a full width
+split at the bottom of the window, using [`:botright`][botright]. You can
+change this by setting `g:picker_split` in your vimrc. For example, to open a
+full width split at the top of the window, set:
+
+```viml
+let g:picker_split = 'topleft'
+```
+
+See [`opening-window`][opening-window] for other valid values.
+
 To specify the height of the window in which the fuzzy selector is opened in
 Neovim, set `g:picker_height` in your vimrc. The default is 10 lines:
 
@@ -139,6 +150,7 @@ Copyright © 2016-2017 [Scott Stevenson].
 
 vim-picker is distributed under the terms of the [ISC licence].
 
+[botright]: https://vimhelp.appspot.com/windows.txt.html#%3Abotright
 [Command-T]: https://github.com/wincent/command-t
 [ctrlp.vim]: https://github.com/ctrlpvim/ctrlp.vim
 [Dein.vim]: https://github.com/Shougo/dein.vim
@@ -147,6 +159,7 @@ vim-picker is distributed under the terms of the [ISC licence].
 [ISC licence]: https://opensource.org/licenses/ISC
 [Neovim]: https://neovim.io/
 [nvim-terminal]: https://neovim.io/doc/user/nvim_terminal_emulator.html
+[opening-window]: https://vimhelp.appspot.com/windows.txt.html#opening-window
 [packages]: https://vimhelp.appspot.com/repeat.txt.html#packages
 [packpath]: https://vimhelp.appspot.com/options.txt.html#%27packpath%27
 [pick]: https://github.com/calleerlandsson/pick

--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -110,7 +110,7 @@ function! s:PickerTermopen(list_command, vim_command, callback) abort
         endif
     endfunction
 
-    execute 'botright' g:picker_height . 'new'
+    execute g:picker_split g:picker_height . 'new'
     let l:term_command = a:list_command . '|' . g:picker_selector . '>' .
                 \ l:callback.filename
     let s:picker_job_id = termopen(l:term_command, l:callback)

--- a/doc/picker.txt
+++ b/doc/picker.txt
@@ -68,6 +68,15 @@ set:
 >
     let g:picker_selector = 'pick'
 <
+By default, vim-picker in Neovim will run the fuzzy selector in a full width
+split at the bottom of the window, using |:botright|. You can change this by
+setting `g:picker_split` in your |vimrc|. For example, to open a full width
+split at the top of the window, set:
+>
+    let g:picker_split = 'topleft'
+<
+See |opening-window| for other valid values.
+
 ==============================================================================
 ISSUES                                                           *picker-issues*
 

--- a/plugin/picker.vim
+++ b/plugin/picker.vim
@@ -14,6 +14,12 @@ else
     let g:picker_selector = 'fzy --lines=' . &lines
 endif
 
+if exists('g:picker_split')
+    call picker#CheckIsString(g:picker_split, 'g:picker_split')
+else
+    let g:picker_split = 'botright'
+endif
+
 if exists('g:picker_height')
     call picker#CheckIsNumber(g:picker_height, 'g:picker_height')
 else


### PR DESCRIPTION
Previously, vim-picker always opened a full width split at the bottom of the window to run the fuzzy selector, using  [`:botright`](https://vimhelp.appspot.com/windows.txt.html#%3Abotright). This can now be configured by the user by setting `g:picker_split` in their vimrc. Valid values can be found under [`opening-window`](https://vimhelp.appspot.com/windows.txt.html#opening-window) in the Vim documentation.