### PR TITLE
Don't show line numbers in picker buffers

### DIFF
--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -116,7 +116,7 @@ function! s:PickerTermopen(list_command, vim_command, callback) abort
     let s:picker_job_id = termopen(l:term_command, l:callback)
     let b:picker_statusline = 'Picker [command: ' . a:vim_command .
                 \ ', directory: ' . getcwd() . ']'
-    setlocal statusline=%{b:picker_statusline}
+    setlocal nonumber norelativenumber statusline=%{b:picker_statusline}
     setfiletype picker
     startinsert
 endfunction


### PR DESCRIPTION
This change disables both absolute and relative line numbering in picker buffers.