### PR TITLE
Add :PickerStag to open a tag in a new split

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ vim-picker provides the following commands:
 * `:PickerVsplit`: Pick a file to edit in a new vertical split.
 * `:PickerBuffer`: Pick a buffer to edit in the current window.
 * `:PickerTag`: Pick a tag to jump to in the current window.
+* `:PickerStag`: Pick a tag to jump to in a new horizontal split.
 * `:PickerBufferTag`: Pick a tag from the current buffer to jump to.
 * `:PickerHelp`: Pick a help tag to jump to in the current window.
 
@@ -79,6 +80,7 @@ vim-picker defines the following [`<Plug>`][plug-mappings] mappings:
 * `<Plug>PickerVsplit`: Execute `:PickerVsplit`.
 * `<Plug>PickerBuffer`: Execute `:PickerBuffer`.
 * `<Plug>PickerTag`: Execute `:PickerTag`.
+* `<Plug>PickerStag`: Execute `:PickerStag`.
 * `<Plug>PickerBufferTag`: Execute `:PickerBufferTag`.
 * `<Plug>PickerHelp`: Execute `:PickerHelp`.
 
@@ -94,6 +96,7 @@ nmap <unique> <leader>pt <Plug>PickerTabedit
 nmap <unique> <leader>pv <Plug>PickerVsplit
 nmap <unique> <leader>pb <Plug>PickerBuffer
 nmap <unique> <leader>p] <Plug>PickerTag
+nmap <unique> <leader>pw <Plug>PickerStag
 nmap <unique> <leader>po <Plug>PickerBufferTag
 nmap <unique> <leader>ph <Plug>PickerHelp
 ```

--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -269,6 +269,11 @@ function! picker#Tag() abort
     call s:PickString(s:ListTagsCommand(), 'tag')
 endfunction
 
+function! picker#Stag() abort
+    " Run fuzzy selector to choose a tag and call stag on it.
+    call s:PickString(s:ListTagsCommand(), 'stag')
+endfunction
+
 function! picker#BufferTag() abort
     " Run fuzzy selector to choose a tag from the current file and call
     " tag on it.

--- a/doc/picker.txt
+++ b/doc/picker.txt
@@ -38,6 +38,9 @@ vim-picker provides the following commands:
                                                              *picker-:PickerTag*
 :PickerTag              Pick a tag to jump to in the current window.
 
+                                                            *picker-:PickerStag*
+:PickerStag             Pick a tag to jump to in a new horizontal split.
+
                                                        *picker-:PickerBufferTag*
 :PickerBufferTag        Pick a tag from the current buffer to jump to.
 
@@ -55,6 +58,7 @@ vim-picker provides the following |<Plug>| mappings:
 <Plug>PickerVsplit      Execute :PickerVsplit
 <Plug>PickerBuffer      Execute :PickerBuffer
 <Plug>PickerTag         Execute :PickerTag
+<Plug>PickerStag        Execute :PickerStag
 <Plug>PickerBufferTag   Execute :PickerBufferTag
 <Plug>PickerHelp        Execute :PickerHelp
 

--- a/plugin/picker.vim
+++ b/plugin/picker.vim
@@ -32,6 +32,7 @@ command -bar PickerTabedit call picker#Tabedit()
 command -bar PickerVsplit call picker#Vsplit()
 command -bar PickerBuffer call picker#Buffer()
 command -bar PickerTag call picker#Tag()
+command -bar PickerStag call picker#Stag()
 command -bar PickerBufferTag call picker#BufferTag()
 command -bar PickerHelp call picker#Help()
 
@@ -41,5 +42,6 @@ nnoremap <silent> <Plug>PickerTabedit :PickerTabedit<CR>
 nnoremap <silent> <Plug>PickerVsplit :PickerVsplit<CR>
 nnoremap <silent> <Plug>PickerBuffer :PickerBuffer<CR>
 nnoremap <silent> <Plug>PickerTag :PickerTag<CR>
+nnoremap <silent> <Plug>PickerStag :PickerStag<CR>
 nnoremap <silent> <Plug>PickerBufferTag :PickerBufferTag<CR>
 nnoremap <silent> <Plug>PickerHelp :PickerHelp<CR>


### PR DESCRIPTION
`:PickerStag` allows fuzzy selecting a tag to open in a new horizontal split, using the [`:stag`](https://vimhelp.appspot.com/windows.txt.html#%3Astag) command.