### PR TITLE
Allow the user to choose the file listing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ nmap <unique> <leader>ph <Plug>PickerHelp
 
 ## Configuration
 
+In directories which are not inside a Git repository, vim-picker uses `rg` to
+list files, falling back to `find` if `rg` is not available. To use an
+alternative to `rg`, set `g:picker_find_executable` and `g:picker_find_flags`
+in your vimrc. For example, to use [`fd`][fd] set:
+
+```viml
+let g:picker_find_executable = 'fd'
+let g:picker_find_flags = '--color=never'
+```
+
 `fzy` is used as the default fuzzy selector. To use an alternative selector,
 set `g:picker_selector` in your vimrc. For example, set
 
@@ -144,6 +154,7 @@ vim-picker is distributed under the terms of the [ISC licence].
 [Command-T]: https://github.com/wincent/command-t
 [ctrlp.vim]: https://github.com/ctrlpvim/ctrlp.vim
 [Dein.vim]: https://github.com/Shougo/dein.vim
+[fd]: https://github.com/sharkdp/fd
 [fzy-tmux]: https://github.com/jhawthorn/fzy/blob/master/contrib/fzy-tmux
 [fzy]: https://github.com/jhawthorn/fzy
 [ISC licence]: https://opensource.org/licenses/ISC

--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -16,7 +16,7 @@ endfunction
 function! s:ListFilesCommand() abort
     " Return a shell command suitable for listing the files in the
     " current directory, based on whether the current directory is a Git
-    " repository and if ripgrep is installed.
+    " repository and if the preferred find tool is installed.
     "
     " Returns
     " -------
@@ -24,8 +24,8 @@ function! s:ListFilesCommand() abort
     "     Shell command to list files in the current directory.
     if executable('git') && s:InGitRepository()
         return 'git ls-files --cached --exclude-standard --others'
-    elseif executable('rg')
-        return 'rg --color=never --files'
+    elseif executable(g:picker_find_executable)
+        return g:picker_find_executable . ' ' . g:picker_find_flags
     else
         return 'find . -type f'
     endif

--- a/doc/picker.txt
+++ b/doc/picker.txt
@@ -65,6 +65,14 @@ vim-picker provides the following |<Plug>| mappings:
 ==============================================================================
 CONFIGURATION                                             *picker-configuration*
 
+In directories which are not inside a Git repository, vim-picker will use `rg`
+to list files, falling back to `find` if `rg` is not available. To use an
+alternative to `rg`, set `g:picker_find_executable` and `g:picker_find_flags`
+in your |vimrc|. For example, to use `fd` (https://github.com/sharkdp/fd) set:
+>
+    let g:picker_find_executable = 'fd'
+    let g:picker_find_flags = '--color=never'
+<
 By default vim-picker will use `fzy` (https://github.com/jhawthorn/fzy) as the
 fuzzy selector. You can change this by setting `g:picker_selector` in your
 |vimrc|. For example, to use `pick` (https://github.com/calleerlandsson/pick)

--- a/plugin/picker.vim
+++ b/plugin/picker.vim
@@ -8,6 +8,19 @@ endif
 
 let g:loaded_picker = 1
 
+if exists('g:picker_find_executable')
+    call picker#CheckIsString(g:picker_find_executable,
+                \ 'g:picker_find_executable')
+else
+    let g:picker_find_executable = 'rg'
+endif
+
+if exists('g:picker_find_flags')
+    call picker#CheckIsString(g:picker_find_flags, 'g:picker_find_flags')
+else
+    let g:picker_find_flags = '--color=never --files'
+endif
+
 if exists('g:picker_selector')
     call picker#CheckIsString(g:picker_selector, 'g:picker_selector')
 else


### PR DESCRIPTION
If the user wishes to use a file listing tool other than ripgrep, they can now do so by setting `g:picker_find_executable` to the name of the executable, and `g:picker_find_flags` to any command line flags required by it. For example, to use [`fd`](https://github.com/sharkdp/fd) set:

```viml
let g:picker_find_executable = 'fd'
let g:picker_find_flags = '--color=never'
```