### PR TITLE
Use consistent variable names for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,17 +114,19 @@ let g:picker_find_flags = '--color=never'
 ```
 
 `fzy` is used as the default fuzzy selector. To use an alternative selector,
-set `g:picker_selector` in your vimrc. For example, set
+set `g:picker_selector_executable` and `g:picker_selector_flags` in your vimrc.
+For example, to use `pick` set:
 
 ```viml
-let g:picker_selector = 'pick'
+let g:picker_selector_executable = 'pick'
+let g:picker_selector_flags = ''
 ```
 
-to use `pick`. vim-picker has been tested with `fzy`, `pick`, and `selecta`,
-but any well behaved command line filter should work. If you run Vim within
-[tmux], setting `g:picker_selector` to the [`fzy-tmux`][fzy-tmux] script
-distributed with `fzy` will open the fuzzy selector in a new tmux pane below
-Vim, providing an interface similar to using vim-picker with Neovim.
+vim-picker has been tested with `fzy`, `pick`, and `selecta`, but any well
+behaved command line filter should work. If you run Vim within [tmux], setting
+`g:picker_selector_executable` to the [`fzy-tmux`][fzy-tmux] script distributed
+with `fzy` will open the fuzzy selector in a new tmux pane below Vim, providing
+an interface similar to using vim-picker with Neovim.
 
 By default, vim-picker in Neovim will run the fuzzy selector in a full width
 split at the bottom of the window, using [`:botright`][botright]. You can

--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -111,8 +111,8 @@ function! s:PickerTermopen(list_command, vim_command, callback) abort
     endfunction
 
     execute g:picker_split g:picker_height . 'new'
-    let l:term_command = a:list_command . '|' . g:picker_selector . '>' .
-                \ l:callback.filename
+    let l:term_command = a:list_command . '|' . g:picker_selector_executable .
+                \ ' ' . g:picker_selector_flags . '>' . l:callback.filename
     let s:picker_job_id = termopen(l:term_command, l:callback)
     let b:picker_statusline = 'Picker [command: ' . a:vim_command .
                 \ ', directory: ' . getcwd() . ']'
@@ -133,8 +133,10 @@ function! s:PickerSystemlist(list_command, callback) abort
     " callback.on_select : String -> Void
     "     Function executed with the item selected by the user as the
     "     first argument.
+    let l:command = a:list_command . '|' . g:picker_selector_executable . ' '
+                \ . g:picker_selector_flags
     try
-        call a:callback.on_select(systemlist(a:list_command . '|' . g:picker_selector)[0])
+        call a:callback.on_select(systemlist(l:command)[0])
     catch /E684/
     endtry
     redraw!
@@ -156,8 +158,8 @@ function! s:Picker(list_command, vim_command, callback) abort
     " callback.on_select : String -> Void
     "     Function executed with the item selected by the user as the
     "     first argument.
-    if !executable(split(g:picker_selector)[0])
-        echomsg 'Error:' split(g:picker_selector)[0] 'executable not found'
+    if !executable(g:picker_selector_executable)
+        echomsg 'Error:' g:picker_selector_executable 'executable not found'
         return
     endif
 

--- a/doc/picker.txt
+++ b/doc/picker.txt
@@ -74,11 +74,12 @@ in your |vimrc|. For example, to use `fd` (https://github.com/sharkdp/fd) set:
     let g:picker_find_flags = '--color=never'
 <
 By default vim-picker will use `fzy` (https://github.com/jhawthorn/fzy) as the
-fuzzy selector. You can change this by setting `g:picker_selector` in your
-|vimrc|. For example, to use `pick` (https://github.com/calleerlandsson/pick)
-set:
+fuzzy selector. You can change this by setting `g:picker_selector_executable`
+and `g:picker_selector_flags` in your |vimrc|. For example, to use `pick`
+(https://github.com/calleerlandsson/pick) set:
 >
-    let g:picker_selector = 'pick'
+    let g:picker_selector_executable = 'pick'
+    let g:picker_selector_flags = ''
 <
 By default, vim-picker in Neovim will run the fuzzy selector in a full width
 split at the bottom of the window, using |:botright|. You can change this by

--- a/plugin/picker.vim
+++ b/plugin/picker.vim
@@ -8,6 +8,11 @@ endif
 
 let g:loaded_picker = 1
 
+if exists('g:picker_selector')
+    echomsg 'Error: g:picker_selector is deprecated; see :help'
+                \ 'picker-configuration.'
+endif
+
 if exists('g:picker_find_executable')
     call picker#CheckIsString(g:picker_find_executable,
                 \ 'g:picker_find_executable')
@@ -21,10 +26,18 @@ else
     let g:picker_find_flags = '--color=never --files'
 endif
 
-if exists('g:picker_selector')
-    call picker#CheckIsString(g:picker_selector, 'g:picker_selector')
+if exists('g:picker_selector_executable')
+    call picker#CheckIsString(g:picker_selector_executable,
+                \ 'g:picker_selector_executable')
 else
-    let g:picker_selector = 'fzy --lines=' . &lines
+    let g:picker_selector_executable = 'fzy'
+endif
+
+if exists('g:picker_selector_flags')
+    call picker#CheckIsString(g:picker_selector_flags,
+                \ 'g:picker_selector_flags')
+else
+    let g:picker_selector_flags = '--lines=' . &lines
 endif
 
 if exists('g:picker_split')


### PR DESCRIPTION
For consistency with `g:picker_find_executable` and `g:picker_find_flags`, `g:picker_selector` has been split into `g:picker_selector_executable` and `g:picker_selector_flags`. Configuration of the form:
```viml
let g:picker_selector = 'prog --arg=value'
```
becomes
```viml
let g:picker_selector_executable = 'prog'
let g:picker_selector_flags = '--arg=value'
```