### PR TITLE
Update URL of `pick` upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ vim-picker is distributed under the terms of the [ISC licence].
 [opening-window]: https://neovim.io/doc/user/windows.html#opening-window
 [packages]: https://neovim.io/doc/user/repeat.html#packages
 [packpath]: https://neovim.io/doc/user/options.html#'packpath'
-[pick]: https://github.com/calleerlandsson/pick
+[pick]: https://github.com/mptre/pick
 [plug-mappings]: https://neovim.io/doc/user/map.html#%3CPlug%3E
 [ripgrep]: https://github.com/BurntSushi/ripgrep
 [Scott Stevenson]: https://scott.stevenson.io

--- a/doc/picker.txt
+++ b/doc/picker.txt
@@ -77,7 +77,7 @@ and `g:picker_find_flags` in your |vimrc|. For example, to use ripgrep
 By default vim-picker will use `fzy` (https://github.com/jhawthorn/fzy) as the
 fuzzy selector. You can change this by setting `g:picker_selector_executable`
 and `g:picker_selector_flags` in your |vimrc|. For example, to use `pick`
-(https://github.com/calleerlandsson/pick) set:
+(https://github.com/mptre/pick) set:
 >
     let g:picker_selector_executable = 'pick'
     let g:picker_selector_flags = ''


### PR DESCRIPTION
`pick`'s upstream URL has changed from https://github.com/calleerlandsson/pick to https://github.com/mptre/pick: this PR reflects that change in the vim-picker documentation.