### PR TITLE
Use tjump instead of tag for picker

### DIFF
--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -268,7 +268,7 @@ endfunction
 
 function! picker#Tag() abort
     " Run fuzzy selector to choose a tag and call tag on it.
-    call s:PickString(s:ListTagsCommand(), 'tag')
+    call s:PickString(s:ListTagsCommand(), 'tjump')
 endfunction
 
 function! picker#Stag() abort
@@ -279,7 +279,7 @@ endfunction
 function! picker#BufferTag() abort
     " Run fuzzy selector to choose a tag from the current file and call
     " tag on it.
-    call s:PickString(s:ListBufferTagsCommand(expand('%:p')), 'tag')
+    call s:PickString(s:ListBufferTagsCommand(expand('%:p')), 'tjump')
 endfunction
 
 function! picker#Help() abort


### PR DESCRIPTION
The vim `tag` command picks the first matching tag for a given keyword. In the projects I deal with, there are often multiple matches.

This changes picker to use the `tjump` command, which will jump to the given tag if it's the only match, or open a picker menu if there are multiple matches.