### PR TITLE
Use Python 3.6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 ---
 language: python
+python:
+  - "3.6"
 install:
   - pip install vim-vint
 script:


### PR DESCRIPTION
With this change vint is run with Python 3.6 on Travis CI, rather than 2.7.