### PR TITLE
Add support for user customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ vim-picker provides the following commands:
 - `:PickerStag`: Pick a tag to jump to in a new horizontal split.
 - `:PickerBufferTag`: Pick a tag from the current buffer to jump to.
 - `:PickerHelp`: Pick a help tag to jump to in the current window.
+- `:PickerListUserCommands`: Show a list of user-defined commands (see below).
 
 ## Key mappings
 
@@ -84,11 +85,12 @@ vim-picker defines the following [`<Plug>`][plug-mappings] mappings:
 - `<Plug>PickerStag`: Execute `:PickerStag`.
 - `<Plug>PickerBufferTag`: Execute `:PickerBufferTag`.
 - `<Plug>PickerHelp`: Execute `:PickerHelp`.
+- `<Plug>PickerListUserCommands`: Execute `:PickerListUserCommands`.
 
 These are not mapped to key sequences, to allow you to choose those that best
 fit your workflow and don't conflict with other plugins you use. However if you
-have no preference, the following snippet maps each mapping to a mnemonic key
-sequence:
+have no preference, the following snippet maps the main mappings to mnemonic key
+sequences:
 
 ```viml
 nmap <unique> <leader>pe <Plug>PickerEdit
@@ -148,6 +150,56 @@ To specify the height of the window in which the fuzzy selector is opened, set
 ```viml
 let g:picker_height = 10
 ```
+
+## User-defined commands
+
+Users may customise how vim-picker gathers search candidates and processes
+selections with user-defined commands.
+
+A user-defined command consists of four parts:
+
+1. A unique identifier. This is used to register the command and later execute
+   it.
+2. A shell command that generates a newline-separated list of candidates to pass
+   to the fuzzy selector. The shell command can utilize pipes to chain commands
+   together.
+3. A selection type of `string` or `file`. String selections are left unchanged
+   when received from the fuzzy selector. File selections are treated as
+   filenames: spaces and special characters are escaped.
+4. A Vim command, such as `edit` or `tjump`. The item selected by the user,
+   after escaping as a filename if the selection type is `file`, is passed to
+   this Vim command as a single argument.
+
+User-defined commands are registered using the `picker#Register()` function,
+which takes an identifier, selection type, Vim command, and shell command as
+described above as arguments:
+
+```viml
+call picker#Register({id}, {selection_type}, {vim_command}, {shell_command})
+```
+
+For example, to register a user-defined command named `notes` to edit a Markdown
+file stored in `~/notes`, add the following to your vimrc:
+
+```viml
+call picker#Register('notes', 'file', 'edit', 'find ~/notes -name "*.md"')
+```
+
+This command can then be executed using the `picker#Execute()` function, which
+takes the ID of the user-defined command as a single argument:
+
+```viml
+call picker#Execute('notes')
+```
+
+You may wish to define a mapping for this, such as:
+
+```viml
+nmap <leader>n :call picker#Execute('notes')<CR>
+```
+
+To show a list of all registered user-defined commands, execute
+`:PickerListUserCommands`.
 
 ## Copyright
 

--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -2,6 +2,27 @@
 " Maintainer: Scott Stevenson <scott@stevenson.io>
 " Source:     https://github.com/srstevenson/vim-picker
 
+if !exists('s:user_command_registry')
+    let s:user_command_registry = {}
+endif
+
+function! s:RightPadText(text, length) abort
+    " Right pad text with trailing spaces.
+    "
+    " Parameters
+    " ----------
+    " text : String
+    "     The text to be padded.
+    " length : Number
+    "     The length to be padded to.
+    "
+    " Returns
+    " -------
+    " String
+    "     The right padded text.
+    return a:text . repeat(' ', a:length - len(a:text))
+endfunction
+
 function! s:InGitRepository() abort
     " Determine if the current directory is a Git repository.
     "
@@ -330,4 +351,90 @@ function! picker#Close() abort
     elseif exists('*job_stop')
         call job_stop(term_getjob(s:picker_buf_num))
     endif
+endfunction
+
+function! picker#Register(id, selection_type, vim_cmd, shell_cmd) abort
+    " Register a new user-defined command.
+    "
+    " Parameters
+    " ----------
+    " id : String
+    "     A unique name that identifies the user-defined command.
+    " selection_type : 'file' or 'string'
+    "     Whether vim-picker will match a string or filename. Special
+    "     characters in filenames are escaped.
+    " vim_cmd : String
+    "     A Vim command that takes the user selected string as an argument,
+    "     for example 'edit', 'tjump', or 'buffer'.
+    " shell_cmd : String
+    "     A shell command that provides a newline delimited list of strings
+    "     to pass to the fuzzy selector.
+    "
+    " Returns
+    " -------
+    " Boolean
+    "     v:true if registration succeeds, v:false otherwise.
+    if has_key(s:user_command_registry, a:id)
+        echoerr 'vim-picker: user command with ID "' . a:id . '" already registered'
+        return v:false
+    elseif index(['file', 'string'], a:selection_type) < 0
+        echoerr 'vim-picker: argument "selection_type" of picker#Register()'
+                    \ 'must be either "file" or "string"'
+        return v:false
+    elseif !picker#IsString(a:shell_cmd)
+        echoerr 'vim-picker: argument "shell_cmd" of picker#Register() must be a string'
+        return v:false
+    elseif !picker#IsString(a:vim_cmd)
+        echoerr 'vim-picker: argument "vim_cmd" of picker#Register() must be a string'
+        return v:false
+    endif
+
+    let s:user_command_registry[a:id] = {
+                \ 'selection_type': a:selection_type,
+                \ 'shell_command': a:shell_cmd,
+                \ 'vim_command': a:vim_cmd
+                \ }
+
+    return v:true
+endfunction
+
+function! picker#Execute(id) abort
+    " Execute user-defined command specified by the given ID.
+    "
+    " Parameters
+    " ----------
+    " id : String
+    "     A unique name that identifies the user-defined command.
+    "
+    " Returns
+    " -------
+    " Boolean
+    "     v:true if user-defined command exists, v:false otherwise.
+    if !has_key(s:user_command_registry, a:id)
+        echoerr 'vim-picker: no command registered with ID "' . a:id . '"'
+        return v:false
+    endif
+
+    let l:command = s:user_command_registry[a:id]
+
+    if l:command['selection_type'] ==# 'file'
+        call s:PickFile(l:command['shell_command'], l:command['vim_command'])
+    else
+        call s:PickString(l:command['shell_command'], l:command['vim_command'])
+    endif
+
+    return v:true
+endfunction
+
+function! picker#ListUserCommands() abort
+    " List user-defined commands.
+    echomsg ' ID         | SELECTION TYPE | VIM COMMAND | SHELL COMMAND'
+    for item in items(s:user_command_registry)
+        let l:id = s:RightPadText(item[0], 10)
+        let l:selection_type = s:RightPadText(item[1]['selection_type'], 14)
+        let l:vim_command = s:RightPadText(item[1]['vim_command'], 11)
+        let l:shell_command = item[1]['shell_command']
+        echomsg ' ' . l:id . ' | ' . l:selection_type . ' | ' . l:vim_command
+                    \ . ' | ' . l:shell_command
+    endfor
 endfunction

--- a/doc/picker.txt
+++ b/doc/picker.txt
@@ -7,8 +7,9 @@ CONTENTS                                                       *picker-contents*
     2. Commands ..................................|picker-commands|
     3. Mappings ..................................|picker-mappings|
     4. Configuration .............................|picker-configuration|
-    5. Issues ....................................|picker-issues|
-    6. Licence ...................................|picker-licence|
+    5. Functions .................................|picker-functions|
+    6. Issues ....................................|picker-issues|
+    7. Licence ...................................|picker-licence|
 
 ==============================================================================
 ABOUT                                                             *picker-about*
@@ -47,20 +48,24 @@ vim-picker provides the following commands:
                                                             *picker-:PickerHelp*
 :PickerHelp             Pick a help tag to jump to in the current window.
 
+                                                *picker-:PickerListUserCommands*
+:PickerListUserCommands Display a list of registered user-defined commands.
+
 ==============================================================================
 MAPPINGS                                                       *picker-mappings*
 
 vim-picker provides the following |<Plug>| mappings:
 
-<Plug>PickerEdit        Execute :PickerEdit
-<Plug>PickerSplit       Execute :PickerSplit
-<Plug>PickerTabedit     Execute :PickerTabedit
-<Plug>PickerVsplit      Execute :PickerVsplit
-<Plug>PickerBuffer      Execute :PickerBuffer
-<Plug>PickerTag         Execute :PickerTag
-<Plug>PickerStag        Execute :PickerStag
-<Plug>PickerBufferTag   Execute :PickerBufferTag
-<Plug>PickerHelp        Execute :PickerHelp
+<Plug>PickerEdit                    Execute :PickerEdit
+<Plug>PickerSplit                   Execute :PickerSplit
+<Plug>PickerTabedit                 Execute :PickerTabedit
+<Plug>PickerVsplit                  Execute :PickerVsplit
+<Plug>PickerBuffer                  Execute :PickerBuffer
+<Plug>PickerTag                     Execute :PickerTag
+<Plug>PickerStag                    Execute :PickerStag
+<Plug>PickerBufferTag               Execute :PickerBufferTag
+<Plug>PickerHelp                    Execute :PickerHelp
+<Plug>PickerListUserCommands        Execute :PickerListUserCommands
 
 ==============================================================================
 CONFIGURATION                                             *picker-configuration*
@@ -96,6 +101,38 @@ To specify the height of the window in which the fuzzy selector is opened, set
 >
     let g:picker_height = 10
 <
+
+==============================================================================
+FUNCTIONS                                                     *picker-functions*
+
+                                                              *picker#Execute()*
+picker#Execute({id})
+    Execute the fuzzy selector using the user-defined command with the given
+    identifier.
+
+                                                             *picker#Register()*
+picker#Register({id}, {selection_type}, {vim_command}, {shell_command})
+    Register a new user-defined command.
+
+    When activated with |picker#Execute()|, the output of the shell command
+    will be piped into the fuzzy selector, the line selected by the user will
+    be processed according to {selection_type}, and the processed line will
+    finally be passed as a single argument to {vim_command}.
+
+    {id} is a string specifying a unique name used to identify the
+    user-defined command with |picker#Execute()|.
+
+    {selection_type} is a string equal to either 'string' or 'file'. 'string'
+    selections are passed unchanged as a single argument to {vim_command}.
+    'file' selections are treated as filenames: spaces and special characters
+    are escaped before executing {vim_command}.
+
+    {vim_command} is a string specifying the Vim command which will be called
+    with the user's selection as a single argument.
+
+    {shell_command} is a string specifying a shell command consisting of
+    either a single command or a series of piped commands that will generate a
+    newline separated list of candidates to be piped to the fuzzy selector.
 
 ==============================================================================
 ISSUES                                                           *picker-issues*

--- a/plugin/picker.vim
+++ b/plugin/picker.vim
@@ -100,6 +100,7 @@ command -bar PickerTag call picker#Tag()
 command -bar PickerStag call picker#Stag()
 command -bar PickerBufferTag call picker#BufferTag()
 command -bar PickerHelp call picker#Help()
+command -bar PickerListUserCommands call picker#ListUserCommands()
 
 nnoremap <silent> <Plug>PickerEdit :PickerEdit<CR>
 nnoremap <silent> <Plug>PickerSplit :PickerSplit<CR>
@@ -110,3 +111,4 @@ nnoremap <silent> <Plug>PickerTag :PickerTag<CR>
 nnoremap <silent> <Plug>PickerStag :PickerStag<CR>
 nnoremap <silent> <Plug>PickerBufferTag :PickerBufferTag<CR>
 nnoremap <silent> <Plug>PickerHelp :PickerHelp<CR>
+nnoremap <silent> <Plug>PickerListUserCommands :PickerListUserCommands<CR>


### PR DESCRIPTION
This is a functional first draft, but I'm not certain I made the best choices.  This PR will fix #36.

Changes:

1.  Users can add custom commands with `:call PickerRegister(id, selection_type, vim_cmd, shell_cmd)`.
2.  Users can remove custom commands with `:PickerUnregister id`.
3.  Users can list custom commands with `:PickerListUserCommands`.  Commands are listed to `:messages`.
4.  Users can run custom commands with `:PickerActivate id`.
5.  Add a section to documentation for user-defined commands.  [Preview](https://github.com/srstevenson/vim-picker/blob/533fb35271e280154e7d329c2fd6649412949397/README.md#user-defined-commands)

### Concerns:

1.  This API mixes commands and functions.  My initial tests failed to create a command that correctly transferred multiple quoted parameters to the function call with `:call picker#Register(<f-args>)<cr>`.  It seems the quoting of the shell command causes the problems users may want to avoid.

    - Option 1: Leave it.
    - Option 2: Convert customization commands to functions.

2.  Autoloading.  `PickerRegister` is a public function in *./plugin/picker.vim*, and all it does it call `picker#Register` from *./autoload/picker.vim*.  This seemed the better option, instead of putting the bulk of the function code under *./plugin/*, to keep the benefit of vim's autoloading.  It also appears that `PickerRegister` in *./plugin/* is necessary to trigger autoloading of `picker#Register`; even if I make `picker#Register` public by renaming it to `PickerRegister`, it won't be available when the *.vimrc* loads.

    - No alternatives.

3.  `<Plug>` maps.  I haven't determined how, if possible, to create a `<Plug>` mapping that can take an ID argument, so I've declined to add them at this time.  If arguments are not possible, should I still make a `<Plug>` mapping for `PickerListUserCommands`?  My OCD is torn between a consistent API that is inconsistent with existing commands vs. an inconsistent API that is partially consistent with existing commands.  I'm leaning toward the latter and will probably update the PR to add the single `<Plug>` mapping if no preference is given.

4.  Error messages.  I've adopted the style in this snippet:
    ```vim
    if 0 > index(['file', 'string'], l:selection_type)
       echoerr 'picker#Register Expected argument "selection_type" to have a value of "file" or "string"'
       return v:false
    ```
    And afterward saw the `picker#CheckIsString` function.  Since it doesn't return a `bool`, I've left the code I originally wrote.

     - Option 1: Update `picker#CheckIsString` to return `v:true` or `v:false`, and use `picker#CheckIsString` instead.
     - Option 2: Convert my `echoerr` prefix to use `vim-picker:` like `picker#CheckIsString` does.
     - Option 3: Leave it.

Tested on Archlinux with neovim v0.3.1

### Test setup:

```sh
mkdir vim-picker-test
cd vim-picker-test
git clone https://github.com/srstevenson/vim-picker.git
cd vim-picker
git fetch origin pull/38/head:pr-38
git checkout pr-38
cd ..
touch -d '2018-12-01' 2018-01-01-january.md
touch -d '2018-11-01' 2018-02-02-february.md
cat > init.vim <<EOF
set rtp^=./vim-picker

runtime! plugin/**/*.vim

call PickerRegister(
	\ 'recent-notes',
	\ 'file',
	\ 'edit',
	\ 'find . -path ./git -prune -o -iname "*.md" -printf "%T@ %p\n" | sort -n | cut -d" " -f2-'
	\ )

nmap <leader>pr :PickerActivate recent-notes<cr>
EOF
nvim -u ./init.vim --noplugin
# Try <leader>pr mapping.  Observe no errors.  And february.md is sorted before january.md.
# Try :PickerUnregister recent-notes
# Try :PickerListUserCommands
```