### PR TITLE
Ensure terminal window is closed after selection

### DIFF
--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -103,7 +103,7 @@ function! s:PickerTermopen(list_command, vim_command, callback) abort
                 \ }
 
     function! l:callback.on_exit(job_id, data, event) abort
-        bdelete!
+        close!
         call win_gotoid(l:self.window_id)
         if filereadable(l:self.filename)
             try
@@ -149,7 +149,7 @@ function! s:PickerTermStart(list_command, vim_command, callback) abort
                 \ }
 
     function! l:callback.exit_cb(...) abort
-        bdelete!
+        close!
         call win_gotoid(l:self.window_id)
         if filereadable(l:self.filename)
             try


### PR DESCRIPTION
In the case that the vim-picker window contains the only listed buffer (for example, because the window from which vim-picker was invoked contains an unlisted buffer such as Netrw), `:bdelete!` will not close the vim-picker window after the selector has exited. Therefore, use `:close!` instead of `:bdelete!` so that the window is closed.

I've tested this briefly in Neovim 0.3.3, but it still needs further testing including in Vim.

Closes #37. Thanks to @jssee for reporting this.