### PR TITLE
Refactor type checking of user-set variables

### DIFF
--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -271,36 +271,6 @@ function! s:PickFile(list_command, vim_command) abort
     call s:Picker(a:list_command, a:vim_command, l:callback)
 endfunction
 
-function! picker#IsNumber(variable) abort
-    " Determine if a variable is a number.
-    "
-    " Parameters
-    " ----------
-    " variable : Any
-    "     Value of the variable.
-    "
-    " Returns
-    " -------
-    " Boolean
-    "     v:true if the variable is a number, v:false otherwise.
-    return type(a:variable) ==# type(0)
-endfunction
-
-function! picker#IsString(variable) abort
-    " Determine if a variable is a string.
-    "
-    " Parameters
-    " ----------
-    " variable : Any
-    "     Value of the variable.
-    "
-    " Returns
-    " -------
-    " Boolean
-    "     v:true if the variable is a string, v:false otherwise.
-    return type(a:variable) ==# type('')
-endfunction
-
 function! picker#Edit() abort
     " Run fuzzy selector to choose a file and call edit on it.
     call s:PickFile(s:ListFilesCommand(), 'edit')

--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -271,32 +271,34 @@ function! s:PickFile(list_command, vim_command) abort
     call s:Picker(a:list_command, a:vim_command, l:callback)
 endfunction
 
-function! picker#CheckIsNumber(variable, name) abort
-    " Print an error message if variable is not of type Number.
+function! picker#IsNumber(variable) abort
+    " Determine if a variable is a number.
     "
     " Parameters
     " ----------
     " variable : Any
     "     Value of the variable.
-    " name : String
-    "     Name of the variable.
-    if type(a:variable) != type(0)
-        echoerr 'vim-picker:' a:name 'must be a number'
-    endif
+    "
+    " Returns
+    " -------
+    " Boolean
+    "     v:true if the variable is a number, v:false otherwise.
+    return type(a:variable) ==# type(0)
 endfunction
 
-function! picker#CheckIsString(variable, name) abort
-    " Print an error message if variable is not of type String.
+function! picker#IsString(variable) abort
+    " Determine if a variable is a string.
     "
     " Parameters
     " ----------
     " variable : Any
     "     Value of the variable.
-    " name : String
-    "     Name of the variable.
-    if type(a:variable) != type('')
-        echoerr 'vim-picker:' a:name 'must be a string'
-    endif
+    "
+    " Returns
+    " -------
+    " Boolean
+    "     v:true if the variable is a string, v:false otherwise.
+    return type(a:variable) ==# type('')
 endfunction
 
 function! picker#Edit() abort

--- a/plugin/picker.vim
+++ b/plugin/picker.vim
@@ -8,6 +8,36 @@ endif
 
 let g:loaded_picker = 1
 
+function! picker#IsNumber(variable) abort
+    " Determine if a variable is a number.
+    "
+    " Parameters
+    " ----------
+    " variable : Any
+    "     Value of the variable.
+    "
+    " Returns
+    " -------
+    " Boolean
+    "     v:true if the variable is a number, v:false otherwise.
+    return type(a:variable) ==# type(0)
+endfunction
+
+function! picker#IsString(variable) abort
+    " Determine if a variable is a string.
+    "
+    " Parameters
+    " ----------
+    " variable : Any
+    "     Value of the variable.
+    "
+    " Returns
+    " -------
+    " Boolean
+    "     v:true if the variable is a string, v:false otherwise.
+    return type(a:variable) ==# type('')
+endfunction
+
 if exists('g:picker_selector')
     echoerr 'vim-picker: g:picker_selector is deprecated; see :help'
                 \ 'picker-configuration.'

--- a/plugin/picker.vim
+++ b/plugin/picker.vim
@@ -14,40 +14,49 @@ if exists('g:picker_selector')
 endif
 
 if exists('g:picker_find_executable')
-    call picker#CheckIsString(g:picker_find_executable,
-                \ 'g:picker_find_executable')
+    if !picker#IsString(g:picker_find_executable)
+        echoerr 'vim-picker: g:picker_find_executable must be a string'
+    endif
 else
     let g:picker_find_executable = 'fd'
 endif
 
 if exists('g:picker_find_flags')
-    call picker#CheckIsString(g:picker_find_flags, 'g:picker_find_flags')
+    if !picker#IsString(g:picker_find_flags)
+        echoerr 'vim-picker: g:picker_find_flags must be a string'
+    endif
 else
     let g:picker_find_flags = '--color never --type f'
 endif
 
 if exists('g:picker_selector_executable')
-    call picker#CheckIsString(g:picker_selector_executable,
-                \ 'g:picker_selector_executable')
+    if !picker#IsString(g:picker_selector_executable)
+        echoerr 'vim-picker: g:picker_selector_executable must be a string'
+    endif
 else
     let g:picker_selector_executable = 'fzy'
 endif
 
 if exists('g:picker_selector_flags')
-    call picker#CheckIsString(g:picker_selector_flags,
-                \ 'g:picker_selector_flags')
+    if !picker#IsString(g:picker_selector_flags)
+        echoerr 'vim-picker: g:picker_selector_flags must be a string'
+    endif
 else
     let g:picker_selector_flags = '--lines=' . &lines
 endif
 
 if exists('g:picker_split')
-    call picker#CheckIsString(g:picker_split, 'g:picker_split')
+    if !picker#IsString(g:picker_split)
+        echoerr 'vim-picker: g:picker_split must be a string'
+    endif
 else
     let g:picker_split = 'botright'
 endif
 
 if exists('g:picker_height')
-    call picker#CheckIsNumber(g:picker_height, 'g:picker_height')
+    if !picker#IsNumber(g:picker_height)
+        echoerr 'vim-picker: g:picker_height must be a number'
+    endif
 else
     let g:picker_height = 10
 endif


### PR DESCRIPTION
Previously, the functions which checked the type of user-set configuration variables both checked the type of the variable, and printed an error message if the type was incorrect. In retrospect, this
is a mixing of responsibilities. Now, the functions just check the type of the variable passed to them and return a boolean. At the call site the value of this boolean is used to determine whether an error message is printed.