### PR TITLE
Delete vim-picker buffers after closing window

### DIFF
--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -79,6 +79,12 @@ function! s:ListHelpTagsCommand() abort
     return 'cut -f 1 ' . join(findfile('doc/tags', &runtimepath, -1))
 endfunction
 
+function! s:CloseWindowAndDeleteBuffer() abort
+    " Close the current window, deleting buffers that are no longer displayed.
+    set bufhidden=delete
+    close!
+endfunction
+
 function! s:PickerTermopen(list_command, vim_command, callback) abort
     " Open a Neovim terminal emulator buffer in a new window using termopen,
     " execute list_command piping its output to the fuzzy selector, and call
@@ -103,7 +109,7 @@ function! s:PickerTermopen(list_command, vim_command, callback) abort
                 \ }
 
     function! l:callback.on_exit(job_id, data, event) abort
-        close!
+        call s:CloseWindowAndDeleteBuffer()
         call win_gotoid(l:self.window_id)
         if filereadable(l:self.filename)
             try


### PR DESCRIPTION
After changing from `:bdelete!` to `:close!` in #39 to ensure the window opened by vim-picker is closed when all other buffers are unlisted, vim-picker buffers are hidden but not deleted in Neovim if [`'hidden'`](https://neovim.io/doc/user/options.html#'hidden') is set. This commit changes `bufhidden` to `delete` before calling `:close!`, to cause the vim-picker buffer to be deleted.