### PR TITLE
Remove plugin/picker.vim dependency from autoload/picker.vim

### DIFF
--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -6,6 +6,21 @@ if !exists('s:user_command_registry')
     let s:user_command_registry = {}
 endif
 
+function! s:IsString(variable) abort
+    " Determine if a variable is a string.
+    "
+    " Parameters
+    " ----------
+    " variable : Any
+    "     Value of the variable.
+    "
+    " Returns
+    " -------
+    " Boolean
+    "     v:true if the variable is a string, v:false otherwise.
+    return type(a:variable) ==# type('')
+endfunction
+
 function! s:RightPadText(text, length) abort
     " Right pad text with trailing spaces.
     "
@@ -416,10 +431,10 @@ function! picker#Register(id, selection_type, vim_cmd, shell_cmd) abort
         echoerr 'vim-picker: argument "selection_type" of picker#Register()'
                     \ 'must be either "file" or "string"'
         return v:false
-    elseif !picker#IsString(a:shell_cmd)
+    elseif !s:IsString(a:shell_cmd)
         echoerr 'vim-picker: argument "shell_cmd" of picker#Register() must be a string'
         return v:false
-    elseif !picker#IsString(a:vim_cmd)
+    elseif !s:IsString(a:vim_cmd)
         echoerr 'vim-picker: argument "vim_cmd" of picker#Register() must be a string'
         return v:false
     endif


### PR DESCRIPTION
Previously, code in `autoload/picker.vim` called functions from `plugin/picker.vim`, and assumed `plugin/picker.vim` had already been loaded. This is normally the case, however there are some circumstances where it is not.

When using vim-plug and configuring a user defined vim-picker command in your vimrc, the vimrc calls the autoloaded `picker#Register()` function *before* vim-plug has loaded `plugin/picker.vim`. This leads to an error as reported by @nickrw in #47.

To solve this, we inelegantly but pragmatically remove the `plugin/picker.vim` dependency from `autoload/picker.vim` by vendoring the `picker#IsString` function inside `autoload/picker.vim`.

Closes #47.