### PR TITLE
Add parentheses to plug mappings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,16 +81,16 @@ vim-picker provides the following commands:
 
 vim-picker defines the following [`<Plug>`][plug-mappings] mappings:
 
-- `<Plug>PickerEdit`: Execute `:PickerEdit`.
-- `<Plug>PickerSplit`: Execute `:PickerSplit`.
-- `<Plug>PickerTabedit`: Execute `:PickerTabedit`.
-- `<Plug>PickerVsplit`: Execute `:PickerVsplit`.
-- `<Plug>PickerBuffer`: Execute `:PickerBuffer`.
-- `<Plug>PickerTag`: Execute `:PickerTag`.
-- `<Plug>PickerStag`: Execute `:PickerStag`.
-- `<Plug>PickerBufferTag`: Execute `:PickerBufferTag`.
-- `<Plug>PickerHelp`: Execute `:PickerHelp`.
-- `<Plug>PickerListUserCommands`: Execute `:PickerListUserCommands`.
+- `<Plug>(PickerEdit)`: Execute `:PickerEdit`.
+- `<Plug>(PickerSplit)`: Execute `:PickerSplit`.
+- `<Plug>(PickerTabedit)`: Execute `:PickerTabedit`.
+- `<Plug>(PickerVsplit)`: Execute `:PickerVsplit`.
+- `<Plug>(PickerBuffer)`: Execute `:PickerBuffer`.
+- `<Plug>(PickerTag)`: Execute `:PickerTag`.
+- `<Plug>(PickerStag)`: Execute `:PickerStag`.
+- `<Plug>(PickerBufferTag)`: Execute `:PickerBufferTag`.
+- `<Plug>(PickerHelp)`: Execute `:PickerHelp`.
+- `<Plug>(PickerListUserCommands)`: Execute `:PickerListUserCommands`.
 
 These are not mapped to key sequences, to allow you to choose those that best
 fit your workflow and don't conflict with other plugins you use. However if you
@@ -98,16 +98,22 @@ have no preference, the following snippet maps the main mappings to mnemonic key
 sequences:
 
 ```viml
-nmap <unique> <leader>pe <Plug>PickerEdit
-nmap <unique> <leader>ps <Plug>PickerSplit
-nmap <unique> <leader>pt <Plug>PickerTabedit
-nmap <unique> <leader>pv <Plug>PickerVsplit
-nmap <unique> <leader>pb <Plug>PickerBuffer
-nmap <unique> <leader>p] <Plug>PickerTag
-nmap <unique> <leader>pw <Plug>PickerStag
-nmap <unique> <leader>po <Plug>PickerBufferTag
-nmap <unique> <leader>ph <Plug>PickerHelp
+nmap <unique> <leader>pe <Plug>(PickerEdit)
+nmap <unique> <leader>ps <Plug>(PickerSplit)
+nmap <unique> <leader>pt <Plug>(PickerTabedit)
+nmap <unique> <leader>pv <Plug>(PickerVsplit)
+nmap <unique> <leader>pb <Plug>(PickerBuffer)
+nmap <unique> <leader>p] <Plug>(PickerTag)
+nmap <unique> <leader>pw <Plug>(PickerStag)
+nmap <unique> <leader>po <Plug>(PickerBufferTag)
+nmap <unique> <leader>ph <Plug>(PickerHelp)
 ```
+
+Note that these mappings now have parentheses (e.g. `<Plug>(PickerBuffer)`
+rather than `<Plug>PickerBuffer`) to fix an issue whereby Vim would pause
+before executing a mapping if its name was a prefix of another mapping. The old
+mappings without parentheses are deprecated, but remain present for backward
+compatibility.
 
 ## Configuration
 

--- a/doc/picker.txt
+++ b/doc/picker.txt
@@ -65,16 +65,21 @@ MAPPINGS                                                       *picker-mappings*
 
 vim-picker provides the following |<Plug>| mappings:
 
-<Plug>PickerEdit                    Execute :PickerEdit
-<Plug>PickerSplit                   Execute :PickerSplit
-<Plug>PickerTabedit                 Execute :PickerTabedit
-<Plug>PickerVsplit                  Execute :PickerVsplit
-<Plug>PickerBuffer                  Execute :PickerBuffer
-<Plug>PickerTag                     Execute :PickerTag
-<Plug>PickerStag                    Execute :PickerStag
-<Plug>PickerBufferTag               Execute :PickerBufferTag
-<Plug>PickerHelp                    Execute :PickerHelp
-<Plug>PickerListUserCommands        Execute :PickerListUserCommands
+<Plug>(PickerEdit)                  Execute :PickerEdit
+<Plug>(PickerSplit)                 Execute :PickerSplit
+<Plug>(PickerTabedit)               Execute :PickerTabedit
+<Plug>(PickerVsplit)                Execute :PickerVsplit
+<Plug>(PickerBuffer)                Execute :PickerBuffer
+<Plug>(PickerTag)                   Execute :PickerTag
+<Plug>(PickerStag)                  Execute :PickerStag
+<Plug>(PickerBufferTag)             Execute :PickerBufferTag
+<Plug>(PickerHelp)                  Execute :PickerHelp
+<Plug>(PickerListUserCommands)      Execute :PickerListUserCommands
+
+The above mappings replace previous mappings that lacked the parentheses to
+fix an issue whereby Vim would pause before executing a mapping if its name
+was a prefix of another mapping. The old mappings without parentheses are
+deprecated, but remain present for backward compatibility.
 
 ==============================================================================
 CONFIGURATION                                             *picker-configuration*

--- a/plugin/picker.vim
+++ b/plugin/picker.vim
@@ -102,6 +102,20 @@ command -bar PickerBufferTag call picker#BufferTag()
 command -bar PickerHelp call picker#Help()
 command -bar PickerListUserCommands call picker#ListUserCommands()
 
+nnoremap <silent> <Plug>(PickerEdit) :PickerEdit<CR>
+nnoremap <silent> <Plug>(PickerSplit) :PickerSplit<CR>
+nnoremap <silent> <Plug>(PickerTabedit) :PickerTabedit<CR>
+nnoremap <silent> <Plug>(PickerVsplit) :PickerVsplit<CR>
+nnoremap <silent> <Plug>(PickerBuffer) :PickerBuffer<CR>
+nnoremap <silent> <Plug>(PickerTag) :PickerTag<CR>
+nnoremap <silent> <Plug>(PickerStag) :PickerStag<CR>
+nnoremap <silent> <Plug>(PickerBufferTag) :PickerBufferTag<CR>
+nnoremap <silent> <Plug>(PickerHelp) :PickerHelp<CR>
+nnoremap <silent> <Plug>(PickerListUserCommands) :PickerListUserCommands<CR>
+
+" The following mappings are deprecated but remain for backward compatibility.
+" They suffer an issue whereby Vim will pause before executing a mapping if
+" its name is a prefix of another mapping.
 nnoremap <silent> <Plug>PickerEdit :PickerEdit<CR>
 nnoremap <silent> <Plug>PickerSplit :PickerSplit<CR>
 nnoremap <silent> <Plug>PickerTabedit :PickerTabedit<CR>


### PR DESCRIPTION
The plug mapping `<Plug>PickerBuffer` is treated ambiguously due to `<Plug>PickerBufferTag` and suffers a delay due to vim's keybinding timeout.

Add parentheses to the plug mapping names to create unique sequences and
prevent delays from ambiguity.

Update documentation.  Deprecate old mappings.  Recommend new mappings.

Fixes #50

I may have rushed this, so I'd appreciate a double-check.