### PR TITLE
Fix tags breaking when searching multiple tagfiles

### DIFF
--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -91,7 +91,7 @@ function! s:ListTagsCommand() abort
     " -------
     " String
     "     Shell command to list known tags.
-    return 'grep -v "^!_TAG_" ' . join(tagfiles()) . ' | cut -f 1 | sort -u'
+    return 'grep -vh "^!_TAG_" ' . join(tagfiles()) . ' | cut -f 1 | sort -u'
 endfunction
 
 function! s:ListBufferTagsCommand(filename) abort


### PR DESCRIPTION
Found this problem when there are multiple tagfiles defined; we'll end up receiving a lot of file names in the tag search buffer, making it a little useless.

Tested and working under BSD grep 2.5.1 (MacOS).

From `man grep` (BSD):

```
     -h, --no-filename
             Never print filename headers (i.e. filenames) with output
             lines.
```

From `man grep` (GNU):

```
       -h, --no-filename
              Suppress the prefixing of file names on output.  This is the
              default when there is only one file (or only standard input)
              to search.
```
