### PR TITLE
Allow specifying a custom file listing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,15 +117,28 @@ compatibility.
 
 ## Configuration
 
-In directories which are not inside a Git repository, vim-picker uses `fd` to
-list files, falling back to `find` if `fd` is not available. To use an
-alternative to `fd`, set `g:picker_find_executable` and `g:picker_find_flags` in
-your vimrc. For example, to use [`ripgrep`][ripgrep] set:
+By default, vim-picker uses Git to list files in Git repositories, and `fd`
+outside of Git repositories, falling back to `find` if `fd` is not available. To
+use an alternative method of listing files, for example because you want to
+customise the flags passed to Git, because you use a different version control
+system, or because you want to use an alternative to `fd` or `find`, a custom
+file listing tool can be used.
+
+To use a custom file listing tool, set `g:picker_custom_find_executable` and
+`g:picker_custom_find_flags` in your vimrc. For example, to use
+[`ripgrep`][ripgrep] set:
 
 ```vim
-let g:picker_find_executable = 'rg'
-let g:picker_find_flags = '--color never --files'
+let g:picker_custom_find_executable = 'rg'
+let g:picker_custom_find_flags = '--color never --files'
 ```
+
+If `g:picker_custom_find_executable` is set, and the executable it references is
+found, it will always be used in place of Git, `fd`, or `find`. Therefore you
+may want to make `g:picker_custom_find_executable` a wrapper script that
+implements your own checks and fallbacks: for example using `hg` in Mercurial
+repositories, `ripgrep` elsewhere, and falling back to `find` if `ripgrep` is
+not installed.
 
 `fzy` is used as the default fuzzy selector. To use an alternative selector, set
 `g:picker_selector_executable` and `g:picker_selector_flags` in your vimrc. For

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ nmap <unique> <leader>ph <Plug>(PickerHelp)
 ```
 
 Note that these mappings now have parentheses (e.g. `<Plug>(PickerBuffer)`
-rather than `<Plug>PickerBuffer`) to fix an issue whereby Vim would pause
-before executing a mapping if its name was a prefix of another mapping. The old
+rather than `<Plug>PickerBuffer`) to fix an issue whereby Vim would pause before
+executing a mapping if its name was a prefix of another mapping. The old
 mappings without parentheses are deprecated, but remain present for backward
 compatibility.
 

--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -51,17 +51,21 @@ endfunction
 
 function! s:ListFilesCommand() abort
     " Return a shell command suitable for listing the files in the
-    " current directory, based on whether the current directory is a Git
-    " repository and if the preferred find tool is installed.
+    " current directory, based on whether the user has specified a
+    " custom find tool, and if not, whether the current directory is a
+    " Git repository and if fd is installed.
     "
     " Returns
     " -------
     " String
     "     Shell command to list files in the current directory.
-    if executable('git') && s:InGitRepository()
+    if exists('g:picker_custom_find_executable') &&
+                \ executable(g:picker_custom_find_executable)
+        return g:picker_custom_find_executable . ' ' . g:picker_custom_find_flags
+    elseif executable('git') && s:InGitRepository()
         return 'git ls-files --cached --exclude-standard --others'
-    elseif executable(g:picker_find_executable)
-        return g:picker_find_executable . ' ' . g:picker_find_flags
+    elseif executable('fd')
+        return 'fd --color never --type f'
     else
         return 'find . -type f'
     endif

--- a/doc/picker.txt
+++ b/doc/picker.txt
@@ -84,15 +84,30 @@ deprecated, but remain present for backward compatibility.
 ==============================================================================
 CONFIGURATION                                             *picker-configuration*
 
-In directories which are not inside a Git repository, vim-picker will use `fd`
+By default, vim-picker uses Git to list files inside Git repositories. In
+directories which are not inside a Git repository, vim-picker will use `fd`
 (https://github.com/sharkdp/fd) to list files, falling back to `find` if `fd`
-is not available. To use an alternative to `fd`, set `g:picker_find_executable`
-and `g:picker_find_flags` in your |vimrc|. For example, to use ripgrep
+is not available.
+
+To use an alternative method of listing files, for example because you want to
+customise the flags passed to Git, because you use a different version control
+system, or because you want to use an alternative to `fd` or `find`, a custom
+file listing tool can be used.
+
+To use a custom file listing tool, set `g:picker_custom_find_executable` and
+`g:picker_custom_find_flags` in your |vimrc|. For example, to use ripgrep
 (https://github.com/BurntSushi/ripgrep) set:
 >
-    let g:picker_find_executable = 'rg'
-    let g:picker_find_flags = '--color never --files'
+    let g:picker_custom_find_executable = 'rg'
+    let g:picker_custom_find_flags = '--color never --files'
 <
+If `g:picker_custom_find_executable` is set, and the executable it references
+is found, it will always be used in place of Git, `fd`, or `find`. Therefore
+you may want to make `g:picker_custom_find_executable` a wrapper script that
+implements your own checks and fallbacks: for example using `hg` in Mercurial
+repositories, `ripgrep` elsewhere, and falling back to `find` if `ripgrep` is
+not installed.
+
 By default vim-picker will use `fzy` (https://github.com/jhawthorn/fzy) as the
 fuzzy selector. You can change this by setting `g:picker_selector_executable`
 and `g:picker_selector_flags` in your |vimrc|. For example, to use `pick`

--- a/plugin/picker.vim
+++ b/plugin/picker.vim
@@ -38,25 +38,24 @@ function! picker#IsString(variable) abort
     return type(a:variable) ==# type('')
 endfunction
 
-if exists('g:picker_selector')
-    echoerr 'vim-picker: g:picker_selector is deprecated; see :help'
-                \ 'picker-configuration.'
+for var in ['g:picker_find_executable', 'g:picker_find_flags', 'g:picker_selector']
+    if exists(var)
+        echoerr 'vim-picker:' var 'is deprecated; see :help picker-configuration.'
+    endif
+endfor
+
+if exists('g:picker_custom_find_executable')
+    if !picker#IsString(g:picker_custom_find_executable)
+        echoerr 'vim-picker: g:picker_custom_find_executable must be a string'
+    endif
 endif
 
-if exists('g:picker_find_executable')
-    if !picker#IsString(g:picker_find_executable)
-        echoerr 'vim-picker: g:picker_find_executable must be a string'
+if exists('g:picker_custom_find_flags')
+    if !picker#IsString(g:picker_custom_find_flags)
+        echoerr 'vim-picker: g:picker_custom_find_flags must be a string'
     endif
 else
-    let g:picker_find_executable = 'fd'
-endif
-
-if exists('g:picker_find_flags')
-    if !picker#IsString(g:picker_find_flags)
-        echoerr 'vim-picker: g:picker_find_flags must be a string'
-    endif
-else
-    let g:picker_find_flags = '--color never --type f'
+    let g:picker_custom_find_flags = ''
 endif
 
 if exists('g:picker_selector_executable')


### PR DESCRIPTION
If specified, this will always be used instead of Git, `fd`, or `find`. This is useful if you want to customise the flags passed to Git, because you use a different version control system, or because you want to use an alternative to `fd` or `find`.