### PR TITLE
Allow running fuzzy selector in current window

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ To specify the height of the window in which the fuzzy selector is opened, set
 let g:picker_height = 10
 ```
 
+If `g:picker_split` is set to the string `none`, no new split will be opened and
+the fuzzy selector will instead be run in the current window:
+
+```vim
+let g:picker_split = 'none'
+```
+
 ## Custom commands
 
 For use cases not covered by the builtin functions, vim-picker also exposes

--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -419,6 +419,9 @@ function! picker#Close() abort
         call jobstop(s:picker_job_id)
     elseif exists('*job_stop')
         call job_stop(term_getjob(s:picker_buf_num))
+        if g:picker_split ==# 'none'
+            silent bdelete!
+        endif
     endif
 endfunction
 

--- a/doc/picker.txt
+++ b/doc/picker.txt
@@ -126,6 +126,11 @@ To specify the height of the window in which the fuzzy selector is opened, set
 >
     let g:picker_height = 10
 <
+If `g:picker_split` is set to the string `none`, no new split will be opened
+and the fuzzy selector will instead be run in the current window:
+>
+    let g:picker_split = 'none'
+<
 
 ==============================================================================
 FUNCTIONS                                                     *picker-functions*


### PR DESCRIPTION
Now if `g:picker_split` is set to the string `none`:
```vim
let g:picker_split = 'none'
```
no new split window will be opened, and the fuzzy selector will instead be run in the current window.

Closes #66.