### PR TITLE
add BufferSplit and BufferVsplit

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ vim-picker provides the following commands:
 - `:PickerVsplit`: Pick a file to edit in a new vertical split. This takes an
   optional directory argument in the same manner as `:PickerEdit`.
 - `:PickerBuffer`: Pick a buffer to edit in the current window.
+- `:PickerBufferSplit`: Pick a buffer to edit in a new horizontal split.
+- `:PickerBufferVsplit`: Pick a buffer to edit in a new vertical split.
 - `:PickerTag`: Pick a tag to jump to in the current window.
 - `:PickerStag`: Pick a tag to jump to in a new horizontal split.
 - `:PickerBufferTag`: Pick a tag from the current buffer to jump to.
@@ -88,6 +90,8 @@ vim-picker defines the following [`<Plug>`][plug-mappings] mappings:
 - `<Plug>(PickerTabedit)`: Execute `:PickerTabedit`.
 - `<Plug>(PickerVsplit)`: Execute `:PickerVsplit`.
 - `<Plug>(PickerBuffer)`: Execute `:PickerBuffer`.
+- `<Plug>(PickerBufferSplit)`: Execute `:PickerBufferSplit`.
+- `<Plug>(PickerBufferVsplit)`: Execute `:PickerBufferVsplit`.
 - `<Plug>(PickerTag)`: Execute `:PickerTag`.
 - `<Plug>(PickerStag)`: Execute `:PickerStag`.
 - `<Plug>(PickerBufferTag)`: Execute `:PickerBufferTag`.

--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -438,6 +438,16 @@ function! picker#Buffer() abort
     call s:PickFile(s:ListBuffersCommand(), 'buffer')
 endfunction
 
+function! picker#BufferSplit() abort
+    " Run fuzzy selector to choose a buffer and call split on it.
+    call s:PickFile(s:ListBuffersCommand(), 'split')
+endfunction
+
+function! picker#BufferVsplit() abort
+    " Run fuzzy selector to choose a buffer and call vsplit on it.
+    call s:PickFile(s:ListBuffersCommand(), 'vsplit')
+endfunction
+
 function! picker#Tag() abort
     " Run fuzzy selector to choose a tag and call tjump on it.
     call s:PickString(s:ListTagsCommand(), 'tjump')

--- a/doc/picker.txt
+++ b/doc/picker.txt
@@ -45,6 +45,12 @@ vim-picker provides the following commands:
                                                           *picker-:PickerBuffer*
 :PickerBuffer              Pick a buffer to edit in the curent window.
 
+                                                     *picker-:PickerBufferSplit*
+:PickerBufferSplit         Pick a buffer to edit in a new horizontal split.
+
+                                                    *picker-:PickerBufferVsplit*
+:PickerBufferVsplit        Pick a buffer to edit in a new vertical split.
+
                                                              *picker-:PickerTag*
 :PickerTag                 Pick a tag to jump to in the current window.
 
@@ -67,6 +73,8 @@ vim-picker provides the following |<Plug>| mappings:
 <Plug>(PickerTabedit)               Execute :PickerTabedit
 <Plug>(PickerVsplit)                Execute :PickerVsplit
 <Plug>(PickerBuffer)                Execute :PickerBuffer
+<Plug>(PickerBufferSplit)           Execute :PickerBufferSplit
+<Plug>(PickerBufferVsplit)          Execute :PickerBufferVsplit
 <Plug>(PickerTag)                   Execute :PickerTag
 <Plug>(PickerStag)                  Execute :PickerStag
 <Plug>(PickerBufferTag)             Execute :PickerBufferTag

--- a/plugin/picker.vim
+++ b/plugin/picker.vim
@@ -88,6 +88,8 @@ command -bar -nargs=? -complete=dir PickerEdit call picker#Edit(<q-args>)
 command -bar -nargs=? -complete=dir PickerSplit call picker#Split(<q-args>)
 command -bar -nargs=? -complete=dir PickerTabedit call picker#Tabedit(<q-args>)
 command -bar -nargs=? -complete=dir PickerVsplit call picker#Vsplit(<q-args>)
+command -bar PickerBufferSplit call picker#BufferSplit()
+command -bar PickerBufferVsplit call picker#BufferVsplit()
 command -bar PickerBuffer call picker#Buffer()
 command -bar PickerTag call picker#Tag()
 command -bar PickerStag call picker#Stag()
@@ -100,6 +102,8 @@ nnoremap <silent> <Plug>(PickerSplit) :PickerSplit<CR>
 nnoremap <silent> <Plug>(PickerTabedit) :PickerTabedit<CR>
 nnoremap <silent> <Plug>(PickerVsplit) :PickerVsplit<CR>
 nnoremap <silent> <Plug>(PickerBuffer) :PickerBuffer<CR>
+nnoremap <silent> <Plug>(PickerBufferSplit) :PickerBufferSplit<CR>
+nnoremap <silent> <Plug>(PickerBufferVsplit) :PickerBufferVsplit<CR>
 nnoremap <silent> <Plug>(PickerTag) :PickerTag<CR>
 nnoremap <silent> <Plug>(PickerStag) :PickerStag<CR>
 nnoremap <silent> <Plug>(PickerBufferTag) :PickerBufferTag<CR>


### PR DESCRIPTION
Hello,

this PR adds two functions:
* `picker#BufferSplit` which opens a buffer in a horizontal split
* `picker#BufferVsplit()` which opens a buffer in a vertical split

They are exposed via the commands `PickerBufferSplit` and `PickerBufferVsplit`.

I tend to use buffers a lot and so I regularly switch between buffers using `PickerBuffer` already, however I have no way to open the selected buffer in a new split. Right now I either do `:vnew` or `:vsplit` followed by `PickerBuffer`, which works but is not ideal.