### PR TITLE
Delete vim-picker buffers in vanilla Vim too

### DIFF
--- a/autoload/picker.vim
+++ b/autoload/picker.vim
@@ -202,7 +202,7 @@ function! s:PickerTermStart(list_command, vim_command, callback) abort
     endif
 
     function! l:callback.exit_cb(...) abort
-        close!
+        call s:CloseWindowAndDeleteBuffer()
         call win_gotoid(l:self.window_id)
         if filereadable(l:self.filename)
             try


### PR DESCRIPTION
See https://github.com/srstevenson/vim-picker/pull/43.

Not sure why but Vim now has this problem too. I don't think there are any disadvantages for the unaffected versions.