### PR TITLE
Remove deprecated mappings

### DIFF
--- a/plugin/picker.vim
+++ b/plugin/picker.vim
@@ -96,7 +96,6 @@ command -bar PickerTag call picker#Tag()
 command -bar PickerStag call picker#Stag()
 command -bar PickerBufferTag call picker#BufferTag()
 command -bar PickerHelp call picker#Help()
-command -bar PickerListUserCommands call picker#ListUserCommands()
 
 nnoremap <silent> <Plug>(PickerEdit) :PickerEdit<CR>
 nnoremap <silent> <Plug>(PickerSplit) :PickerSplit<CR>
@@ -110,4 +109,3 @@ nnoremap <silent> <Plug>(PickerTag) :PickerTag<CR>
 nnoremap <silent> <Plug>(PickerStag) :PickerStag<CR>
 nnoremap <silent> <Plug>(PickerBufferTag) :PickerBufferTag<CR>
 nnoremap <silent> <Plug>(PickerHelp) :PickerHelp<CR>
-nnoremap <silent> <Plug>(PickerListUserCommands) :PickerListUserCommands<CR>


### PR DESCRIPTION
See: e4edd92a0d17e44063379f64b9e22a6772481552

---

I was exploring the various default commands that are set and noticed this one was not hooked up anywhere. It looks like it was deprecated then removed but maybe just got missed in the cleanup.